### PR TITLE
Don't use `auto` with ambiguous initializations

### DIFF
--- a/src/aarith/core/word_array.hpp
+++ b/src/aarith/core/word_array.hpp
@@ -107,7 +107,7 @@ public:
      */
     explicit word_array(std::string_view bs)     {
         // TODO (keszocze) why isn't it constexpr? --> build a test case for that
-        for (auto i = bs.length(), pos = 0UL; i > 0 && pos < Width; --i, ++pos)
+        for (size_t i = bs.length(), pos = 0UL; i > 0 && pos < Width; --i, ++pos)
         {
             switch (bs[i - 1])
             {


### PR DESCRIPTION
`bs.length()` returns `size_t`, which is of type `unsigned long long` on Windows, and thus in mismatch with the `0UL` literal, which is of type `unsigned long`, rendering the type inference ambiguous. So just use `size_t` instead.