### PR TITLE
Do not rely on nonstandard definitions

### DIFF
--- a/src/aarith/posit/posit.hpp
+++ b/src/aarith/posit/posit.hpp
@@ -582,9 +582,11 @@ template <size_t N, size_t ES, typename WT>
 template <size_t N, size_t ES, typename WT>
 [[nodiscard]] constexpr posit<N, ES, WT> posit<N, ES, WT>::pi()
 {
+    constexpr double pi = 3.14159265358979323846;
+
     // This sucks because for big posit types (N >> 32), we will get
     // increasingly inaccurate results.
-    return posit(M_PI);
+    return posit(pi);
 }
 
 template <size_t N, size_t ES, typename WT>

--- a/src/aarith/posit/posit_operations.hpp
+++ b/src/aarith/posit/posit_operations.hpp
@@ -10,6 +10,8 @@
 
 namespace aarith {
 
+using ssize_t = std::ptrdiff_t;
+
 template <size_t N, size_t ES, typename WT>
 [[nodiscard]] constexpr posit<N, ES, WT> negate(const posit<N, ES, WT>& self)
 {


### PR DESCRIPTION
`ssize_t` is a POSIX type and not part of the C++ Standard. `M_PI` is a widely available yet nonstandard mathematical constant.

(In C++20, use `std::numbers::pi`, cf. https://en.cppreference.com/w/cpp/numeric/constants .)